### PR TITLE
Improve visual centering of the content

### DIFF
--- a/_sass/screens/_home.scss
+++ b/_sass/screens/_home.scss
@@ -5,6 +5,9 @@ body.home .app-content {
     display: flex;
     align-items: center;
 
+    // Compensate for the app-header to be the same height as the app-header
+    // to achieve visual centering
+    margin-top: rem(-52px);
     padding: 0;
   }
 }


### PR DESCRIPTION
## What happened

On large screens, the content area makes use display `flex`. But since the header and footer are of different height, it visually did look really centered. 

So the fix is to compensate for this height difference.
 
## Proof Of Work

![ruby_conference_thailand_2019___home](https://user-images.githubusercontent.com/696529/50388994-4653f500-0756-11e9-92ff-9cc5a669774c.png)
