### PR TITLE
Fix openjdk-8-jre setup issue in Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update -qq && \
 RUN curl -sL https://deb.nodesource.com/setup_"$NODE_VERSION".x | bash -
 
 # Install general required core packages, Node JS related packages and Chrome (testing)
-RUN apt-get update -qq && \
+RUN mkdir -p /usr/share/man/man1 && \
+    apt-get update -qq && \
     apt-get install -y --no-install-recommends build-essential libpq-dev nodejs yarn && \
     apt-get install -y --no-install-recommends rsync locales chrpath pkg-config libfreetype6 libfontconfig1 openjdk-8-jre && \
     apt-get clean && \


### PR DESCRIPTION
## What happened

Fix known issue with the setup of `openjdk-8-jre` preventing the build of the Docker image.
 
## Insight

Found the solution here: https://github.com/puckel/docker-airflow/issues/182
 
## Proof Of Work

![_failed___build_2_of_rubyconfth_bug_dockerfile-build_-_semaphore](https://user-images.githubusercontent.com/696529/52332226-a19f2580-2a2c-11e9-954f-6eecb4e67024.png)
