### PR TITLE
Replace text "Get Location" by "View Map'

### DIFF
--- a/_includes/map-venue.html
+++ b/_includes/map-venue.html
@@ -11,7 +11,7 @@
       <span class="locality">Bangkok</span>
       <span class="postal-code">10400</span>
     </address>
-    <a href="https://goo.gl/maps/vnLpSxt1zzw" target="_blank" class="map-venue__btn btn btn--primary btn--lg">Get Location</a>
+    <a href="https://goo.gl/maps/vnLpSxt1zzw" target="_blank" class="map-venue__btn btn btn--primary btn--lg">View Map</a>
   </div>
 </div>
 {% endcapture %}


### PR DESCRIPTION
## What happened

Unclear what "get location" would do. "view map" seems clearer it links to google maps
 
## Insight

`N/A`
 
## Proof Of Work

![home___ruby_conference_thailand_2019](https://user-images.githubusercontent.com/696529/54034276-0b0b8300-41e9-11e9-9c2f-62aec44c1507.png)
