### PR TITLE
Fix: Jittery scrolling on iOS Mobile Safari

### DIFF
--- a/_js/components/AppNavigation/index.js
+++ b/_js/components/AppNavigation/index.js
@@ -91,6 +91,10 @@ class AppNavigation {
    * @param {Event} _event - Scroll event
    * */
   onScroll(_event) {
+    if (this._isMobileNavigation()) {
+      return;
+    }
+
     this._updatePanePosition();
   }
 
@@ -100,6 +104,10 @@ class AppNavigation {
    * @param {Event} _event - Resize event
    * */
   onResize(_event) {
+    if (this._isMobileNavigation()) {
+      return;
+    }
+
     // Scroll back to the top of the page
     window.scrollTo(0, 0);
 


### PR DESCRIPTION
Closes #50 

## What happened

Disable onResize and onScroll event on mobile screens as they are not required.
 
## Insight

`N/A`
 
## Proof Of Work

Test locally via ngrok:

![1____ngrok_http_4000__ngrok_](https://user-images.githubusercontent.com/696529/54032863-5d4aa500-41e5-11e9-9e33-d2d347276ab0.png)

![img_5794](https://user-images.githubusercontent.com/696529/54032895-75babf80-41e5-11e9-97aa-bb8d7ae756e9.PNG)