### PR TITLE
Remove HTML block parsing as we don't use any Markdown syntax

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,7 @@ sass:
 kramdown:
   # All config options: https://jekyllrb.com/docs/configuration/markdown/
   input: GFM
-  parse_block_html: true
+  parse_block_html: false
   auto_ids: false
 
 collections:

--- a/_includes/list-sponsor.html
+++ b/_includes/list-sponsor.html
@@ -1,4 +1,3 @@
-{% capture content %}
 <div class="list-sponsor">
   {% for sponsor_level in site.data.sponsors %}
   <div class="list-sponsor__level">
@@ -15,6 +14,3 @@
   </div>
   {% endfor %}
 </div>
-{% endcapture %}
-{% comment %} Workaround to prevent Markdown to interpret the content as a code snippet {% endcomment %}
-{{ content | replace: '    ', ''}}

--- a/_includes/map-venue.html
+++ b/_includes/map-venue.html
@@ -1,4 +1,3 @@
-{% capture content %}
 <div class="map-venue">
   <div class="map map-venue__map" data-geolocation="13.75893,100.5352453" data-marker="Pullman Bangkok King Power">
     {% comment %}load map for each locations{% endcomment %}
@@ -14,6 +13,3 @@
     <a href="https://goo.gl/maps/vnLpSxt1zzw" target="_blank" class="map-venue__btn btn btn--primary btn--lg">View Map</a>
   </div>
 </div>
-{% endcapture %}
-{% comment %} Workaround to prevent Markdown to interpret the content as a code snippet {% endcomment %}
-{{ content | replace: '    ', ''}}

--- a/index.md
+++ b/index.md
@@ -5,30 +5,30 @@ permalink: /
 ---
 
 <section id="about" class="home-hero">
-<div class="home-hero__brand">
-{% include icon.svg icon="icon-logo" class="home-hero__logo" %}
-</div>
-<div class="home-hero__text">
-<h1 class="home-hero__heading display-heading">Join us for the <strong>first</strong> Ruby Conference in Bangkok</h1>
-</div>
+    <div class="home-hero__brand">
+        {% include icon.svg icon="icon-logo" class="home-hero__logo" %}
+    </div>
+    <div class="home-hero__text">
+        <h1 class="home-hero__heading display-heading">Join us for the <strong>first</strong> Ruby Conference in Bangkok</h1>
+    </div>
 </section>
 
 <section id="speakers" class="home-speaker">
-<h2>Speakers</h2>
-{% include list-keynote-speaker.html %}
-<div class="call-to-action">
-<a href="https://www.papercall.io/rubyconfth" target="_blank" class="call-to-action__btn btn btn--primary btn--lg">Submit your talk</a>
-</div>
+    <h2>Speakers</h2>
+    {% include list-keynote-speaker.html %}
+    <div class="call-to-action">
+        <a href="https://www.papercall.io/rubyconfth" target="_blank" class="call-to-action__btn btn btn--primary btn--lg">Submit your talk</a>
+    </div>
 </section>
 
 <section id="venue" class="home-venue">
-<h2>Venue</h2>
-{% include map-venue.html %}
+    <h2>Venue</h2>
+    {% include map-venue.html %}
 </section>
 
 <section id="sponsors" class="home-sponsor">
-<h2>Sponsors</h2>
-<p>Our event is supported by amazing sponsors and partners.</p>
-{% include list-sponsor.html %}
-<p>If you are interested in supporting our event, reach out to our team: <a href="mailto:sponsor@rubyconfth.com">sponsor@rubyconfth.com</a>. <br />Our sponsors deck will be published soon.</p>
+    <h2>Sponsors</h2>
+    <p>Our event is supported by amazing sponsors and partners.</p>
+    {% include list-sponsor.html %}
+    <p>If you are interested in supporting our event, reach out to our team: <a href="mailto:sponsor@rubyconfth.com">sponsor@rubyconfth.com</a>. <br />Our sponsors deck will be published soon.</p>
 </section>


### PR DESCRIPTION
## What happened

As it's an SPA with very little content managed by developers, we can just use HTML in all pages instead of Markdown. So I disable the parsing of HTML block in Markdown files so that we can keep the normal indenting of HTML code.
 
## Insight

`N/A`
 
## Proof Of Work

`N/A`