### PR TITLE
Change CTA for registration to "Buy Tickets"

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -48,7 +48,7 @@
         </ul>
 
         <div class="app-navigation__register">
-          <a href="https://www.eventpop.me/e/5111-rubyconfth-2019" target="_blank" class="btn btn--primary">Register Now</a>
+          <a href="https://www.eventpop.me/e/5111-rubyconfth-2019" target="_blank" class="btn btn--primary">Buy Tickets</a>
         </div>
 
         <hr/>

--- a/index.md
+++ b/index.md
@@ -11,7 +11,7 @@ permalink: /
     <div class="home-hero__text">
         <h1 class="home-hero__heading display-heading">Join us for the <strong>first</strong> Ruby Conference in Bangkok</h1>
         <div class="call-to-action">
-            <a href="https://www.eventpop.me/e/5111-rubyconfth-2019" target="_blank" class="call-to-action__btn btn btn--primary btn--lg">Register Now</a>
+            <a href="https://www.eventpop.me/e/5111-rubyconfth-2019" target="_blank" class="call-to-action__btn btn btn--primary btn--lg">Buy Tickets</a>
         </div>
     </div>
 </section>


### PR DESCRIPTION
## What happened

As suggested by @matthewmayer, since the registration links to Event Pop, it makes sense to invite potential attendees to buy tickets.
 
## Insight

`N/A`
 
## Proof Of Work

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/56012603-657f8e00-5d17-11e9-885c-2b5fc1827870.jpg)
