### PR TITLE
Rename Day #1 and #2 in the schedule with the actual days of the week

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -5,9 +5,7 @@
       <span class="schedule__day-of-week">6</span>
     </time>
     <div class="schedule__day">
-      <h3 class="schedule__title">
-        Day #1
-      </h3>
+      <h3 class="schedule__title">Friday</h3>
       <ul class="schedule__list-event">
         <li class="schedule__event">
           <time class="schedule__time-slot">9 AM - 10 AM</time>
@@ -39,9 +37,7 @@
       <span class="schedule__day-of-week">7</span>
     </time>
     <div class="schedule__day">
-      <h3 class="schedule__title">
-        Day #2
-      </h3>
+      <h3 class="schedule__title">Saturday</h3>
       <ul class="schedule__list-event">
         <li class="schedule__event">
           <time class="schedule__time-slot">10 AM - 1 PM</time>


### PR DESCRIPTION
## What happened

In order to clarify the actual days on which the event is held, the title for both days now uses the actual days of the week
 
## Insight

Suggested by @matthewmayer 
 
## Proof Of Work

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/56074358-f9665e00-5dda-11e9-8bd7-a15ea1da35d9.jpg)
