### PR TITLE
Remove link to Papercall as the CFP is now closed

### DIFF
--- a/_sass/screens/_home.scss
+++ b/_sass/screens/_home.scss
@@ -109,6 +109,12 @@ body.home .home-hero {
   }
 }
 
+body.home .home-speaker {
+  &__coming-soon {
+    text-align: center;
+  }
+}
+
 body.home .home-sponsor {
   text-align: center;
 

--- a/index.md
+++ b/index.md
@@ -16,9 +16,7 @@ permalink: /
 <section id="speakers" class="home-speaker">
     <h2>Speakers</h2>
     {% include list-keynote-speaker.html %}
-    <div class="call-to-action">
-        <a href="https://www.papercall.io/rubyconfth" target="_blank" class="call-to-action__btn btn btn--primary btn--lg">Submit your talk</a>
-    </div>
+    <p class="home-speaker__coming-soon">Our CFP is now closed. The complete list of speakers is coming soon.</p>
 </section>
 
 <section id="agenda" class="home-agenda">


### PR DESCRIPTION
## What happened

Remove the large button linking to the Papercall page and add a "coming soon" announcement as a placeholder for the complete list of speakers.
 
## Insight

https://www.papercall.io/rubyconfth returns 404 thus break our tests:

![_failed___Build_1_of_rubyconfth_feature_confirmed-sponsor-logos_-_Semaphore](https://user-images.githubusercontent.com/696529/60394676-79869f00-9b52-11e9-848e-4e724179610c.png)
 
## Proof Of Work

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/60394682-9f13a880-9b52-11e9-8d4b-b26617de3909.png)
