### PR TITLE
Adjust schedule and party name on Day 1

### DIFF
--- a/_includes/schedule.html
+++ b/_includes/schedule.html
@@ -20,12 +20,12 @@
           <span class="schedule__event-name">Buffet Lunch</span>
         </li>
         <li class="schedule__event">
-          <time class="schedule__time-slot">2 PM - 5 PM</time>
+          <time class="schedule__time-slot">2 PM - 6 PM</time>
           <span class="schedule__event-name">Talks</span>
         </li>
         <li class="schedule__event">
-          <time class="schedule__time-slot">6 PM - Late</time>
-          <span class="schedule__event-name">After-Party</span>
+          <time class="schedule__time-slot">7 PM - Late</time>
+          <span class="schedule__event-name">Official Party</span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## What happened

- Rename the `after-party` to `official party`
- Change schedule on Day 1 to reflect the latest plan for the party
 
## Insight

`N/A`
	 
## Proof Of Work

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/60394747-5ad4d800-9b53-11e9-9089-0eaf4e5b0741.png)
