### PR TITLE
Fix: speakers list spacing

### DIFF
--- a/_sass/screens/_home.scss
+++ b/_sass/screens/_home.scss
@@ -58,27 +58,15 @@ body.home .home-speaker {
     }
   }
 
-  .list-speaker:not(.list-speaker--keynote) {
-    margin-bottom: 2rem;
-
-    @include media-breakpoint-up('lg') {
-      margin-bottom: 3rem;
-    }
-  }
-
-  .list-speaker--keynote .list-speaker__item {
-    @include media-breakpoint-up('md') {
-      &:nth-child(-n + 2) {
-        margin-bottom: rem(30px);
-      }
-    }
-  }
-
   .list-speaker__item {
     @include media-breakpoint-up('md') {
-      &:nth-child(-n + 18) {
-        margin-bottom: rem(30px);
-      }
+      margin-bottom: rem(30px);
+    }
+  }
+
+  .list-speaker:not(.list-speaker--keynote) .list-speaker__item:nth-last-child(-n+2) {
+    @include media-breakpoint-up('md') {
+      margin-bottom: 0;
     }
   }
 


### PR DESCRIPTION
## What happened

Fix the weird double spacing below the list of speakers:

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/61344854-f9b04280-a87c-11e9-9862-22d3c1c17971.png)
 
## Insight

This was caused by the fact that there are two lists  for speakers stacked up so some CSS rules did not apply:

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/61344910-25332d00-a87d-11e9-96c0-5913f77b24ce.png)

## Proof Of Work

Normal spacing:

![image](https://user-images.githubusercontent.com/696529/61344924-3a0fc080-a87d-11e9-94bf-6b0ea3f2a937.png)
