### PR TITLE
Add tag to the keynote speaker image to different them from the general speakers

### DIFF
--- a/_includes/list-keynote-speaker.html
+++ b/_includes/list-keynote-speaker.html
@@ -3,6 +3,7 @@
   <li class="list-speaker__item">
     <figure class="list-speaker__profile">
       <img src="{{ keynote_speaker.photo_url }}" alt="Photo of {{ keynote_speaker.first_name }} {{ keynote_speaker.last_name }}" class="list-speaker__photo" />
+      <span class="list-speaker__tag">Keynote</span>
       <figcaption class="list-speaker__name text-branded">
         <span>{{ keynote_speaker.first_name }}</span> {{ keynote_speaker.last_name }}
       </figcaption>

--- a/_sass/components/_list-speaker.scss
+++ b/_sass/components/_list-speaker.scss
@@ -19,6 +19,8 @@
   }
 
   &__profile {
+    position: relative;
+
     @include media-breakpoint-up('lg') {
       display: flex;
       flex-wrap: wrap;
@@ -33,6 +35,26 @@
       height: 100%;
       order: 0;
     }
+  }
+
+  &__tag {
+    display: inline-block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: map-get($zIndex, 'high');
+
+    width: rem(100px);
+    height: rem(36px);
+    line-height: rem(36px);
+    padding: 0 10px;
+
+    font-size: 1rem;
+    text-transform: uppercase;
+    font-weight: 600;
+    color: #fff;
+
+    background: map-get($color-brand, 'primary');
   }
 
   &__name {

--- a/_sass/components/_list-speaker.scss
+++ b/_sass/components/_list-speaker.scss
@@ -42,7 +42,7 @@
     position: absolute;
     top: 0;
     left: 0;
-    z-index: map-get($zIndex, 'high');
+    z-index: map-get($zIndex, 'default');
 
     width: rem(100px);
     height: rem(36px);


### PR DESCRIPTION
Fixes #108 

## What happened

Update the list of keynote speakers by adding a visual UI component to differentiate keynote speakers from general speakers.
 
## Insight

Invision design: https://invis.io/74PMIN4H6FB#/336996633_A_1-0_Main_Page
 
## Proof Of Work

*Small Screen*

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/61503614-a36d0c00-aa02-11e9-9fc2-0ed2438c5d37.png)


*Medium Screen*

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/61503595-8a645b00-aa02-11e9-958c-c8f885c2fc99.png)


*Large Screen*

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/61503579-77518b00-aa02-11e9-885b-c1666eb6de6e.png)
