### PR TITLE
Add Charles Nutter as a speaker

### DIFF
--- a/_data/speakers/speakers.yml
+++ b/_data/speakers/speakers.yml
@@ -118,3 +118,9 @@
   photo_url: /assets/images/pages/home/speakers/janko-marohnic.jpg
   bio: |
     Janko is a Ruby off Rails evangelist and a frequent open source contributor. He firmly believes the future of the Ruby ecosystem lies outside of Rails, and frequently blogs about it. He is the Creator of <a href="https://github.com/shrinerb/shrine" target="_blank">Shrine</a>, a modern file attachment library for Ruby.
+- first_name: Charles
+  last_name: Nutter
+  twitter_handle: '@headius'
+  photo_url: /assets/images/pages/home/speakers/charles-nutter.jpg
+  bio: |
+    Charles is one of the JRuby guys. He is a Ruby Hero and Java Champion too! He works every day to make JRuby the best JVM-based Ruby possible while pushing JVM folks and other language authors to keep improving the platform.


### PR DESCRIPTION
## What happened

Include Charles Nutter as a speaker. 
 
## Insight

Re-used his bio from RubyConf India 2019.
 
## Proof Of Work

*Small Screen*

![image](https://user-images.githubusercontent.com/696529/61577424-34caa400-ab11-11e9-9b93-ecb9f88bc237.png)

*Medium Screen*

![image](https://user-images.githubusercontent.com/696529/61577419-25e3f180-ab11-11e9-8eda-0b327d74e64c.png)

*Large Screen*

![image](https://user-images.githubusercontent.com/696529/61577405-06e55f80-ab11-11e9-9e46-285242ae3f9a.png)
