### PR TITLE
Visually differentiate sponsors who also act as partners

### DIFF
--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -11,7 +11,7 @@
       url: https://nimblehq.co/
       logo_url: /assets/images/pages/home/sponsors/logo-nimble.jpg
       is_partner: true
-        partner_text: Official Partner
+      partner_text: Official Partner
     - name: Omise
       url: https://www.omise.co/
       logo_url: /assets/images/pages/home/sponsors/logo-omise.jpg

--- a/_data/sponsors.yml
+++ b/_data/sponsors.yml
@@ -10,6 +10,8 @@
     - name: Nimble
       url: https://nimblehq.co/
       logo_url: /assets/images/pages/home/sponsors/logo-nimble.jpg
+      is_partner: true
+        partner_text: Official Partner
     - name: Omise
       url: https://www.omise.co/
       logo_url: /assets/images/pages/home/sponsors/logo-omise.jpg
@@ -19,6 +21,8 @@
     - name: Gitlab
       url: https://about.gitlab.com/
       logo_url: /assets/images/pages/home/sponsors/logo-gitlab.jpg
+      is_partner: true
+      partner_text: Swag Sponsor
     - name: Matestack
       url: https://matestack.org/
       logo_url: /assets/images/pages/home/sponsors/logo-matestack.jpg

--- a/_includes/list-sponsor.html
+++ b/_includes/list-sponsor.html
@@ -5,8 +5,11 @@
     <ul class="list-sponsor__list-company list-sponsor__list-company--{{ sponsor_level.slug }} list--unstyled">
       {% for company in sponsor_level.companies %}
         <li class="list-sponsor__company">
-          <a href="{{ company.url }}" title="{{ company.name }}" target="_blank">
+          <a href="{{ company.url }}" title="{{ company.name }}" target="_blank" class="list-sponsor__link">
             <img src="{{ company.logo_url }}" alt="{{ company.name }}" />
+            {% if company.is_partner  %}
+              <span class="list-sponsor__tag">{{ company.partner_text }}</span>
+            {% endif %}
           </a>
         </li>
       {% endfor %}

--- a/_sass/components/_list-sponsor.scss
+++ b/_sass/components/_list-sponsor.scss
@@ -10,15 +10,22 @@
   }
 
   &__list-company {
-    display: block;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+
     padding: rem(30px) 0;
   }
 
   &__company {
-    margin-bottom: rem(40px);
+    flex: 50% 1 1;
+    margin-bottom: rem(50px);
 
-    @include media-breakpoint-up('lg') {
-      margin-bottom: 0;
+    &:last-child {
+      @include media-breakpoint-down('sm') {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -31,7 +38,7 @@
     display: block;
 
     position: absolute;
-    bottom: -35%;
+    bottom: -50%;
     left: 50%;
     z-index: map-get($zIndex, 'default');
     transform: translateX(-50%);
@@ -48,73 +55,33 @@
 }
 
 .list-sponsor__list-company {
-  &--platinum {
+  &--ruby .list-sponsor__company:last-child {
+    margin-bottom: 0;
+  }
+
+  &--gold .list-sponsor__company:nth-child(n+3) {
     @include media-breakpoint-up('md') {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-wrap: wrap;
-
-      .list-sponsor__company {
-        @include media-breakpoint-up('md') {
-          flex: 50% 1 1;
-        }
-      }
+      margin-bottom: 0;
     }
   }
 
-  &--gold {
+  &--speaker .list-sponsor__company {
+    margin-bottom: rem(40px);
+
     @include media-breakpoint-up('md') {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      flex-wrap: wrap;
+      flex: 33% 1 1;
+    }
 
-      .list-sponsor__company {
-        @include media-breakpoint-up('md') {
-          flex: 50% 1 1;
-        }
-
-        @include media-breakpoint-up('lg') {
-          margin-bottom: rem(40px);
-        }
-      }
+    &:last-child {
+      margin-bottom: 0;
     }
   }
 
-  &--speaker {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
+  &--partner .list-sponsor__company {
+    margin-bottom: rem(40px);
 
-    .list-sponsor__company {
-      flex: 50% 1 1;
-
-      margin-bottom: rem(30px);
-
-      @include media-breakpoint-up('md') {
-        flex: 33% 1 1;
-      }
-    }
-  }
-
-  &--partner {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    flex-wrap: wrap;
-
-    .list-sponsor__company {
-      flex: 50% 1 1;
-
-      @include media-breakpoint-up('md') {
-        flex: 25% 1 1;
-      }
-
-      @include media-breakpoint-up('lg') {
-        flex: auto 1 1;
-      }
+    @include media-breakpoint-up('md') {
+      flex: 25% 1 1;
     }
   }
 }

--- a/_sass/components/_list-sponsor.scss
+++ b/_sass/components/_list-sponsor.scss
@@ -59,9 +59,17 @@
     margin-bottom: 0;
   }
 
-  &--gold .list-sponsor__company:nth-child(n+3) {
-    @include media-breakpoint-up('md') {
-      margin-bottom: 0;
+  &--gold .list-sponsor__company {
+    &:nth-child(-n+2) {
+      @include media-breakpoint-up('md') {
+        margin-bottom: rem(75px);
+      }
+    }
+
+    &:nth-child(n+3) {
+      @include media-breakpoint-up('md') {
+        margin-bottom: 0;
+      }
     }
   }
 
@@ -72,8 +80,17 @@
       flex: 33% 1 1;
     }
 
+    &:last-child,
+    &:nth-last-child(2) {
+      @include media-breakpoint-down('sm') {
+        margin-bottom: 0;
+      }
+    }
+
     &:last-child {
-      margin-bottom: 0;
+      @include media-breakpoint-up('md') {
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/_sass/components/_list-sponsor.scss
+++ b/_sass/components/_list-sponsor.scss
@@ -10,15 +10,40 @@
   }
 
   &__list-company {
+    display: block;
     padding: rem(30px) 0;
   }
 
   &__company {
-    margin-bottom: rem(30px);
+    margin-bottom: rem(40px);
 
     @include media-breakpoint-up('lg') {
       margin-bottom: 0;
     }
+  }
+
+  &__link {
+    display: block;
+    position: relative;
+  }
+
+  &__tag {
+    display: block;
+
+    position: absolute;
+    bottom: -35%;
+    left: 50%;
+    z-index: map-get($zIndex, 'default');
+    transform: translateX(-50%);
+
+    width: auto;
+    padding: 0 4px;
+
+    color: #fff;
+    font-size: map-get($font-sizes, 'xs');
+    text-transform: uppercase;
+
+    background: #f81c49;
   }
 }
 
@@ -51,7 +76,7 @@
         }
 
         @include media-breakpoint-up('lg') {
-          margin-bottom: rem(30px);
+          margin-bottom: rem(40px);
         }
       }
     }


### PR DESCRIPTION
## What happened

Add small tag below the sponsor image with specific text to show the additional support provided by specific sponsor outside of the sponsorship tier.
 
## Insight

- For Nimble, this PR is required with #111 
- For Gitlab, we discussed on Slack about informing attendees that Gitlab would sponsor swag
 
## Proof Of Work

*Small Screen*

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/62004839-77652f80-b154-11e9-8f06-c637ed8aa986.jpg)

*Medium Screen*

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/62004833-69afaa00-b154-11e9-9c34-6793e44096b3.jpg)


*Large Screen*

![Home___Ruby_Conference_Thailand_2019](https://user-images.githubusercontent.com/696529/62004826-5e5c7e80-b154-11e9-929e-0f156c9c0b87.jpg)
