### PR TITLE
Update deployment to publish past website versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 </p>
 
 <p align="center">
-    <a href='https://semaphoreci.com/nimble/rubyconfth'> <img src='https://semaphoreci.com/api/v1/nimble/rubyconfth/branches/master/badge.svg' alt='Build Status'></a>
+    <a href="https://semaphoreci.com/nimble/rubyconfth"> <img src="https://semaphoreci.com/api/v1/nimble/rubyconfth/branches/master/badge.svg" alt="Build Status"></a>
+    <a href="https://app.netlify.com/sites/bangkokrb-rubyconfth/deploys"> <img src="https://api.netlify.com/api/v1/badges/3dbba728-8b59-40c4-b84e-66010ec3f0cf/deploy-status" alt="Deployment Status"></a>
 </p>
 
 ---

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "_site/"
-  command = "JEKYLL_ENV=production ./bin/build"
+  command = "git submodule update --init --recursive && JEKYLL_ENV=production ./bin/build"


### PR DESCRIPTION
## What happened

- Revisit Netlify deployment commands to pull submodules (for past website versions) 
- Add Netlify status badge

## Insight

That's what the Netlify status badge looks like:

![image](https://user-images.githubusercontent.com/696529/65016287-14bb3380-d94e-11e9-9c73-0a86238fe96f.png)

 
## Proof Of Work

Tested working in this preview deployment: https://deploy-preview-142--bangkokrb-rubyconfth.netlify.com/