### PR TITLE
Cancellation announcement of RubyConf TH 2020

### DIFF
--- a/_sass/screens/_home.scss
+++ b/_sass/screens/_home.scss
@@ -4,9 +4,9 @@
   align-items: center;
 }
 
+.home .cancellation-announcement,
 .home .mailing-list,
-.home .social-platform,
-.home .save-the-date {
+.home .social-platform {
   text-align: center;
 
   @include media-breakpoint-up('md') {
@@ -15,7 +15,7 @@
   }
 }
 
-.home .save-the-date {
+.home .cancellation-announcement {
   padding-bottom: 4rem;
 }
 

--- a/index.md
+++ b/index.md
@@ -5,7 +5,7 @@ permalink: /
 ---
 
 <section class="cancellation-announcement">
-  <p>Due to the uncertainty surrounding COVID19 we have decided to reschedule the next RubyConfTH originally planned for October 2020 to a later date in 2021, to allow us to prepare the best possible conference for you.</p>
+  <p>Due to the uncertainty surrounding COVID-19 we have decided to reschedule the next RubyConfTH, originally planned for October 2020, to a later date in 2021 to allow us to prepare the best possible conference for you.</p>
   <p>Bangkok.rb plans to organize a variety of online and, once possible, offline events in Bangkok for the Ruby community <br /> during the rest of 2020.</p>
 </section>
 

--- a/index.md
+++ b/index.md
@@ -4,14 +4,14 @@ title: Home
 permalink: /
 ---
 
-<section class="save-the-date">
-  <h3>October 16 — 17, 2020</h3>
-  <p>Save the date! RubyConfTH will return in 2020!</p>
+<section class="cancellation-announcement">
+  <p>Due to the uncertainty surrounding COVID19 we have decided to reschedule the next RubyConfTH originally planned for October 2020 to a later date in 2021, to allow us to prepare the best possible conference for you.</p>
+  <p>Bangkok.rb plans to organize a variety of online and, once possible, offline events in Bangkok for the Ruby community <br /> during the rest of 2020.</p>
 </section>
 
 <section class="mailing-list">
   <h3>Join our mailing list</h3>
-  <p class="mailing-list__text">Sign up to receive updates about RubyConf TH 2020</p>
+  <p class="mailing-list__text">Sign up to receive updates about future events</p>
   
   {% include form-mailing-list.html %}
 </section>


### PR DESCRIPTION
## What happened

Unfortunately, update the website with the announcement of the cancellation of RubyConf TH 2020.
 
## Insight

`N/A`
 
## Proof Of Work

*Small Screen*

<img width="261" alt="Screen Shot 2563-03-19 at 17 49 09" src="https://user-images.githubusercontent.com/696529/77059860-38992800-6a0a-11ea-80e0-1083b9d6cf7c.png">

*Large Screen*

<img width="896" alt="Screen Shot 2563-03-19 at 17 49 22" src="https://user-images.githubusercontent.com/696529/77059870-3d5ddc00-6a0a-11ea-8cc1-4de62669c173.png">
