### PR TITLE
Add email registration form for the 2022 conference

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 ---
 url: https://rubyconfth.com
-name: RubyConf TH 2020
+name: RubyConf TH 2022
 permalink: pretty
 relative_permalinks: false
 timezone: Asia/Bangkok

--- a/_includes/form-mailing-list.html
+++ b/_includes/form-mailing-list.html
@@ -1,5 +1,6 @@
 <form action="https://rubyconfth.us20.list-manage.com/subscribe/post?u=fd4a02525718b1d58ebaed6a0&id=4af9421776" method="post" class="form-mailing-list form" target="_blank">
   <div class="form__group">
+    <input type="hidden" name="tags" value="2841779">
     <input type="email" name="EMAIL" placeholder="Enter your email address" class="form__control form__control--lg" required />
     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
     <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fd4a02525718b1d58ebaed6a0_4af9421776" tabindex="-1" value=""></div>

--- a/_includes/form-mailing-list.html
+++ b/_includes/form-mailing-list.html
@@ -4,5 +4,5 @@
     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
     <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fd4a02525718b1d58ebaed6a0_4af9421776" tabindex="-1" value=""></div>
   </div>
-  <button type="submit" class="form-mailing-list__btn btn btn--primary">Add me</button>
+  <button type="submit" class="form-mailing-list__btn btn btn--primary">Count me in</button>
 </form>

--- a/_sass/components/_form-mailing-list.scss
+++ b/_sass/components/_form-mailing-list.scss
@@ -2,15 +2,23 @@
   position: relative;
 
   .form__control {
-    padding-right: 155px;
+    @include media-breakpoint-up('md') {
+      padding-right: 155px;
+    }
   }
 
   .btn {
-    position: absolute;
-    top: 9px;
-    right: 9px;
 
-    height: rem(51px);
-    padding: 0.75rem 2rem;
+    width: 100%;
+
+    @include media-breakpoint-up('md') {
+      position: absolute;
+      top: 9px;
+      right: 9px;
+
+      width: auto;
+      height: rem(51px);
+      padding: 0.75rem 2rem;
+    }
   }
 }

--- a/_sass/screens/_home.scss
+++ b/_sass/screens/_home.scss
@@ -4,7 +4,7 @@
   align-items: center;
 }
 
-.home .cancellation-announcement,
+.home .conference-announcement,
 .home .mailing-list,
 .home .social-platform {
   text-align: center;
@@ -15,8 +15,10 @@
   }
 }
 
-.home .cancellation-announcement {
-  padding-bottom: 4rem;
+.home .conference-announcement {
+  @include media-breakpoint-up('md') {
+    padding-bottom: 4rem;
+  }
 }
 
 .home .mailing-list {

--- a/index.md
+++ b/index.md
@@ -6,8 +6,8 @@ permalink: /
 
 <section class="conference-announcement">
   <p>A comeback of RubyConf TH for 2022 is in the works 🎉</p>
-  <p>The conference is scheduled to take place on December 10-11th 2022 at <a href="https://www.pullmanbangkokkingpower.com/">Pullman Bangkok King Power</a> in Bangkok</p>
-  <p>Standard ticket price is <mark>3,200 THB</mark> for the two-day event inclusive of an international buffet on both days and a welcome party 🥳</p>
+  <p>The conference is scheduled to take place on December 10-11th 2022 at <a href="https://www.pullmanbangkokkingpower.com/">Pullman Bangkok King Power</a> in Bangkok, Thailand</p>
+  <p>Standard ticket price is <mark>3,200 THB</mark> (approx. 89 USD) for the two-day event inclusive of all talks, an international lunch buffet on both days and a ticket to the official party 🥳</p>
 </section>
 
 <section class="mailing-list">

--- a/index.md
+++ b/index.md
@@ -4,7 +4,7 @@ title: Home
 permalink: /
 ---
 
-<section class="cancellation-announcement">
+<section class="conference-announcement">
   <p>A comeback of RubyConf TH for 2022 is in the works 🎉</p>
   <p>The conference is scheduled to take place on December 10-11th 2022 at <a href="https://www.pullmanbangkokkingpower.com/">Pullman Bangkok King Power</a> in Bangkok</p>
   <p>Standard ticket price is <mark>3,200 THB</mark> for the two-day event inclusive of an international buffet on both days and a welcome party 🥳</p>

--- a/index.md
+++ b/index.md
@@ -5,13 +5,14 @@ permalink: /
 ---
 
 <section class="cancellation-announcement">
-  <p>Due to the uncertainty surrounding COVID-19 we have decided to reschedule the next RubyConfTH, originally planned for October 2020, to a later date in 2021 to allow us to prepare the best possible conference for you.</p>
-  <p>Bangkok.rb plans to organize a variety of online and, once possible, offline events in Bangkok for the Ruby community <br /> during the rest of 2020.</p>
+  <p>A comeback of RubyConf TH for 2022 is in the works 🎉</p>
+  <p>The conference is scheduled to take place on December 10-11th 2022 at <a href="https://www.pullmanbangkokkingpower.com/">Pullman Bangkok King Power</a> in Bangkok</p>
+  <p>Standard ticket price is <mark>3,200 THB</mark> for the two-day event inclusive of an international buffet on both days and a welcome party 🥳</p>
 </section>
 
 <section class="mailing-list">
-  <h3>Join our mailing list</h3>
-  <p class="mailing-list__text">Sign up to receive updates about future events</p>
+  <h3>Excited about the event?</h3>
+  <p class="mailing-list__text">Add your email now if you plan to join the event</p>
   
   {% include form-mailing-list.html %}
 </section>


### PR DESCRIPTION
## What happened

Reworked the email registration page.
 
## Insight

All new registration will be tagged with `conference-2022` and be accessible via the segment `Conference 2022 Form Subscribers`:

![Screen Shot 2565-07-17 at 14 21 10](https://user-images.githubusercontent.com/696529/179388286-ffcb1f75-c47c-4309-ac58-6a6357c1b51f.png)

![image](https://user-images.githubusercontent.com/696529/179388414-7f6f1004-b2ee-4ba3-83ed-ed595c46c323.png)
 
## Proof Of Work

|Small Screen|Large Screen|
|-|-|
|![image](https://user-images.githubusercontent.com/696529/179390426-36f91096-ca14-4231-8010-16eb8542857e.png) |![image](https://user-images.githubusercontent.com/696529/179390410-21065594-82e7-4268-bfe2-391edebc582b.png)|