### PR TITLE
Fix: Incorrect year is displayed in the page description

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -32,7 +32,7 @@ defaults:
     values:
       layout: default
       seo:
-        description: "Stay tuned for RubyConf TH 2020"
+        description: "Stay tuned for RubyConf TH 2022"
         image: "/public/images/social/opengraph.png"
 
 includes:


### PR DESCRIPTION
## What happened

Update meta description with the correct year
 
## Insight

I did a grep search across all files. We should be good now.
 
## Proof Of Work

`N/A`