### PR TITLE
Update to the new conference dates

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ permalink: /
 </header>
 <section class="conference-announcement">
   <p>A comeback of RubyConf TH for 2022 is in the works 🎉</p>
-  <p>The conference is scheduled to take place on December 10-11th 2022 at <a href="https://www.pullmanbangkokkingpower.com/">Pullman Bangkok King Power</a> in Bangkok, Thailand</p>
+  <p>The conference is scheduled to take place on December 9-10th 2022 at <a href="https://www.pullmanbangkokkingpower.com/">Pullman Bangkok King Power</a> in Bangkok, Thailand</p>
   <p>Standard ticket price is <mark>3,200 THB</mark> (approx. 89 USD) for the two-day event inclusive of all talks, an international lunch buffet on both days and a ticket to the official party 🥳</p>
 </section>
 


### PR DESCRIPTION
## What happened

Change the text to informal about the new dates.
 
## Insight

Pullman could not keep the Eternity bedroom for the initial dates but could accommodate the event at the Infinity ballroom on Friday and Saturday.
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/696529/189576001-f7153bdf-a862-456e-9317-fba91ce78670.png)