### PR TITLE
Fix typo in the heading for sponsors

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -23,7 +23,7 @@ title: "Home"
       <a class="btn btn--primary" href="https://www.papercall.io/rubyconfth2022" target="_blank">View CFP</a>
     </section>
     <section class="sponsors">
-      <h3>The event is made possible thanks to the support of our oustanding sponsors</h3>
+      <h3>The event is made possible thanks to the support of our outstanding sponsors</h3>
 
       {% render "list_sponsor", sponsors: site.data.sponsors %}
 


### PR DESCRIPTION
## What happened

Fix a typo spotted after the release of @4.1.0
 
## Insight

`N/A`
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/696529/191943637-025768e0-7082-413d-8f3a-38c1782dc5e7.png)