### PR TITLE
Add fathom analytics code

### DIFF
--- a/src/_components/analytics.liquid
+++ b/src/_components/analytics.liquid
@@ -1,6 +1,1 @@
-<script>
-  !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
-    analytics.load("TxlxESGNUiB3pfg4hfHAFO8pjYChQbmN");
-    analytics.page();
-  }}();
-</script>
+<script src="https://fs.rubyconfth.com/script.js" data-site="FOCVQRVQ" defer></script>

--- a/src/_components/head.liquid
+++ b/src/_components/head.liquid
@@ -50,3 +50,5 @@
 <link rel="icon" type="image/x-icon" href="/images/favicon/favicon.ico">
 
 <link rel="manifest" href="/manifest.json"">
+
+<script src="https://fs.rubyconfth.com/script.js" data-site="{{ metadata.fathom_analytics }}" defer></script>

--- a/src/_components/head.liquid
+++ b/src/_components/head.liquid
@@ -51,4 +51,6 @@
 
 <link rel="manifest" href="/manifest.json"">
 
-<script src="https://fs.rubyconfth.com/script.js" data-site="{{ metadata.fathom_analytics }}" defer></script>
+{% if bridgetown.environment == "production" %}
+  {% render "analytics" %}
+{% endif %}

--- a/src/_data/site_metadata.yml
+++ b/src/_data/site_metadata.yml
@@ -8,3 +8,4 @@ title: RubyConf TH 2022
 description: >-
   A community-powered Ruby conference on 9-10 December 2022 in Bangkok, Thailand
 image: /public/images/social/opengraph.png
+fathom_analytics: FOCVQRVQ

--- a/src/_data/site_metadata.yml
+++ b/src/_data/site_metadata.yml
@@ -8,4 +8,3 @@ title: RubyConf TH 2022
 description: >-
   A community-powered Ruby conference on 9-10 December 2022 in Bangkok, Thailand
 image: /public/images/social/opengraph.png
-fathom_analytics: FOCVQRVQ

--- a/src/_layouts/default.liquid
+++ b/src/_layouts/default.liquid
@@ -27,9 +27,5 @@
     </main>
 
     {% render "footer", metadata: site.metadata, social_platforms: site.data.social_platforms %}
-
-    {% if site.environment == "production" %}
-      {% render "analytics" %}
-    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## What happened

Add Fathom Analytics (usefathom.com) - this is like Google Analytics, but better for privacy. Note it uses a custom hostname. 
 
## Insight

The Google Analytics component has been replaced and is [rendered conditionally](https://www.bridgetownrb.com/docs/configuration/environments#conditional-content). 

The domains have been filtered only to allow the script to work on the live site:

![image](https://user-images.githubusercontent.com/696529/193734840-3cf1b604-ebe5-41dc-b954-f6cbf5bfc25c.png)


## Proof of Work

Prior to the domain filtering, it showed a user is live on the preview site:

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/152770/193547831-7c44eb82-f0ad-4f2a-8b2b-75531174dfa7.png">