### PR TITLE
Fix: Fathom Analytics not working

### DIFF
--- a/src/_components/head.liquid
+++ b/src/_components/head.liquid
@@ -47,10 +47,6 @@
 <link rel="icon" type="image/png" sizes="192x192"  href="/images/favicon/android-icon-192x192.png"/>
 <link rel="icon" type="image/png" sizes="32x32" href="/images/favicon/favicon-32x32.png"/>
 <link rel="icon" type="image/png" sizes="16x16" href="/images/favicon/favicon-16x16.png"/>
-<link rel="icon" type="image/x-icon" href="/images/favicon/favicon.ico">
+<link rel="icon" type="image/x-icon" href="/images/favicon/favicon.ico"/>
 
-<link rel="manifest" href="/manifest.json"">
-
-{% if bridgetown.environment == "production" %}
-  {% render "analytics" %}
-{% endif %}
+<link rel="manifest" href="/manifest.json"/>

--- a/src/_layouts/default.liquid
+++ b/src/_layouts/default.liquid
@@ -5,6 +5,11 @@
 
     <link rel="stylesheet" href="{% asset_path stylesheets/application.scss %}" type="text/css"/>
     <script src="{% asset_path javascript/application.js %}" defer></script>
+
+    {% if bridgetown.environment == "production" %}
+      {% render "analytics" %}
+    {% endif %}
+
     {% live_reload_dev_js %}
   </head>
   <body class="{{ resource.data.page_class }}">

--- a/src/_layouts/home.liquid
+++ b/src/_layouts/home.liquid
@@ -5,6 +5,11 @@
 
     <link rel="stylesheet" href="{% asset_path stylesheets/application.scss %}" type="text/css"/>
     <script src="{% asset_path javascript/application.js %}" defer></script>
+    
+    {% if bridgetown.environment == "production" %}
+      {% render "analytics" %}
+    {% endif %}
+
     {% live_reload_dev_js %}
   </head>
   <body class="{{ resource.data.page_class }}">

--- a/src/_layouts/home.liquid
+++ b/src/_layouts/home.liquid
@@ -32,9 +32,5 @@
     </main>
 
     {% render "footer", metadata: site.metadata, social_platforms: site.data.social_platforms %}
-
-    {% if site.environment == "production" %}
-      {% render "analytics" %}
-    {% endif %}
   </body>
 </html>


### PR DESCRIPTION
## What happened

Rework the layouts to render the analytics components.
 
## Insight

By default, components do not have access to any global values, including `bridgetown.environment`. Any property must be passed to the render function. So to conditionally render a component based on the environment, we can either add a property (e.g., `environment: bridgetown.environment`) and do the check inside the component (e.g., {% if environment == "production" %}) or do the check outside of the component. I picked the latter option as it is more obvious what is going on at the layout level.
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/696529/195284716-ab6fb8bd-e576-4c38-8b1a-21c3b21f0d88.png)