### PR TITLE
Add Facebook promo link

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,6 +9,10 @@
 [[redirects]]
   from = "/tickets"
   to = "https://www.eventpop.me/e/13417/rubyconfth-2022"
+
+[[redirects]]
+  from = "/tickets/fbpromo"
+  to = "https://www.eventpop.me/e/13417/rubyconfth-2022?discount_code=FBPROMO"
   
 [[redirects]]
   from = "/sponsors"


### PR DESCRIPTION
## What Happened

Adds redirect from `/tickets/fbpromo` to `https://www.eventpop.me/e/13417/rubyconfth-2022?discount_code=FBPROMO`.

## Insights

The goal is to make it easier to track if the facebook ads lead to ticket sales.

## Proof of Work

`N/A`