### PR TITLE
Add archived version of the 2022 website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ yarn-debug.log*
 
 # Yarn Integrity file
 .yarn-integrity
+
+# Git Submodules
+src/past

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,3 @@ yarn-debug.log*
 
 # Yarn Integrity file
 .yarn-integrity
-
-# Git Submodules
-src/past

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/past/2019"]
 	path = src/past/2019
 	url = https://github.com/bangkokrb/rubyconfth-2019.git
+[submodule "src/past/2022"]
+	path = src/past/2022
+	url = https://github.com/bangkokrb/rubyconfth-2022.git

--- a/src/_components/footer.liquid
+++ b/src/_components/footer.liquid
@@ -23,7 +23,7 @@
         Built with <a href="https://www.ruby-lang.org/en/">Ruby</a> & <a href="https://www.bridgetownrb.com/">Bridgetown</a>
       </div>
       <div class="app-footer__link">
-        Past events: <a href="/past/2019">2019</a>
+        Past events: <a href="/past/2022/">2022</a> - <a href="/past/2019/">2019</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## What happened

- Add a new Git submodule for the 2022 website
- Update the footer with the link to the 2022 website
 
## Insight

The archive version is pushed to: https://github.com/bangkokrb/rubyconfth-2022

The website will be transformed to a landing page for the 2023 event in the next PR.
 
## Proof Of Work

![image](https://user-images.githubusercontent.com/696529/211182390-fcdd5527-757c-43a7-8bc7-a9e4ce258f56.png)