### PR TITLE
Link to new sponsor deck from /sponsors2023

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -15,8 +15,8 @@
   to = "https://www.eventpop.me/e/13417/rubyconfth-2022?discount_code=FBPROMO"
   
 [[redirects]]
-  from = "/sponsors"
-  to = "https://drive.google.com/file/d/1Rgt9qWPaaMf6juoEHyLF_mnltm915IBh/view?usp=sharing"
+  from = "/sponsors2023"
+  to = "https://docs.google.com/presentation/d/e/2PACX-1vT8-zU4gQA-0ZF0ptHkoV1IGEWw-87U_eNZHrdaG3EP89aOjTceIkKBGG7qcXqIOt6YIc4jWXbnureL/pub?start=false&loop=false&delayms=3000"
 
 [[redirects]]
   from = "/slack"


### PR DESCRIPTION
## What Happened

Add a redirect from /sponsors2023 to [the Google slides published URL](https://docs.google.com/presentation/d/e/2PACX-1vT8-zU4gQA-0ZF0ptHkoV1IGEWw-87U_eNZHrdaG3EP89aOjTceIkKBGG7qcXqIOt6YIc4jWXbnureL/pub?start=false&loop=false&delayms=3000).

## Insight

`N/A`

## Proof of Work

Go to: https://deploy-preview-266--bangkokrb-rubyconfth.netlify.app/sponsors2023/