### PR TITLE
Link past conferences on the 404 page

### DIFF
--- a/frontend/stylesheets/components/_error.scss
+++ b/frontend/stylesheets/components/_error.scss
@@ -30,7 +30,8 @@
   &__action {
     display: flex;
 
-    margin-top: 45px;
+    margin-top: 30px;
+    margin-bottom:30px;
   }
 
   &__action a {

--- a/src/404.html
+++ b/src/404.html
@@ -15,6 +15,14 @@ permalink: /404.html
   <hr>
   <div class="error__context">
     <p>
+      Looking for something from our previous conferences?<br/>
+      Check our archived homepage for RubyConfTH 2022 or RubyConfTH 2019.
+    </p>
+    <div class="error__action">
+      <a class="btn btn--outline" href="/past/2022/">2022 site</a>
+      <a class="btn btn--outline" href="/past/2019/">2019 site</a>
+    </div>
+    <p>
       You may want to head back to the homepage.<br />
       If you think something is broken, report a problem.
     </p>


### PR DESCRIPTION
## What happened

Adds links to past sites on the 404 page.

## Insights

For example, if people follow an old link to`/schedule` or `/speakers` while we have the landing page active they can more easily get to what they are looking for.

## Proof Of Work

<img width="741" alt="image" src="https://user-images.githubusercontent.com/152770/212535249-2c57ef69-12b9-4266-8c85-e997d7d73da9.png">