### PR TITLE
Update Gemfile.lock for ruby-lsp

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -141,6 +141,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## What happened

Minor upodate to the Gemfile.lock.
 
## Insight

This change is needed for the new https://github.com/Shopify/ruby-lsp 

## Proof Of Work

`N/A`