### PR TITLE
Fix: Center hero background on the homepage

### DIFF
--- a/frontend/stylesheets/screens/_home.scss
+++ b/frontend/stylesheets/screens/_home.scss
@@ -1,28 +1,35 @@
 body.home .app-hero {
   align-items: flex-start;
 
-  height: rem(400px);
-
   color: $base-font-color;
   text-align: center;
 
-  background: {
-    color: $white;
-    image: url('/images/home/elephant-illustration.png');
-    repeat: no-repeat;
-    position: bottom center;
-    size: contain;
-  };
+  background: $white;
 
   @include media-breakpoint-up('sm') {
-    align-items: center;
     margin-bottom: 4rem;
 
     text-align: left;
+  }
+
+  .container {
+    height: rem(400px);
 
     background: {
-      position: bottom right;
-      size: auto 100%;
+      image: url('/images/home/elephant-illustration.png');
+      repeat: no-repeat;
+      position: bottom center;
+      size: contain;
+    }
+
+    @include media-breakpoint-up('sm') {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+
+      background: {
+        position: bottom right;
+      }
     }
   }
 
@@ -34,8 +41,13 @@ body.home .app-hero {
     background: $white;
   }
 
-  .btn {
+  &__action {
+    align-self: center;
     margin-top: 2rem;
+
+    @include media-breakpoint-up('sm') {
+      align-self: flex-start;
+    }
   }
 }
 

--- a/src/_layouts/home.liquid
+++ b/src/_layouts/home.liquid
@@ -24,7 +24,7 @@
         <div class="app-hero__heading display-3"><span class="app-hero__text">October 6-7, 2023</span></div>
         <small class="app-hero__subheading"><span class="app-hero__text">Novotel Sukhumvit 20 - Bangkok, Thailand</span></small>
 
-        <a href="https://www.eventpop.me/e/15095/rubyconfth-2023" target="_blank" class="btn btn--primary">
+        <a href="https://www.eventpop.me/e/15095/rubyconfth-2023" target="_blank" class="btn btn--primary app-hero__action">
           Buy Tickets {% render "icon", icon: "icon-arrow-right-circle" %}
         </a>
       </div>


### PR DESCRIPTION
## What happened

Move the background styles to the content container to ensure it is centered with the content.
 
## Insight

On very large screens, the illustration was too much on the right 🤦 
 
## Proof Of Work

|Before|After|
|-|-|
|![image](https://github.com/bangkokrb/rubyconfth/assets/696529/af13f86b-aed7-4f77-a6f5-b45bfc35ec1a)|![image](https://github.com/bangkokrb/rubyconfth/assets/696529/7a0465bb-3d8d-42a2-a073-b02a87b3ef65)|