### PR TITLE
Add correct HTML markup

### DIFF
--- a/frontend/stylesheets/components/_list-speaker.scss
+++ b/frontend/stylesheets/components/_list-speaker.scss
@@ -59,7 +59,7 @@
     }
   }
   &__minibio {
-    margin-top: 1rem;
+    margin-top: 0.6rem;
     font-size:map-get(variables.$font-sizes, 'sm');
   }
 }

--- a/frontend/stylesheets/components/_list-speaker.scss
+++ b/frontend/stylesheets/components/_list-speaker.scss
@@ -58,6 +58,10 @@
       margin-top: 0.6rem;
     }
   }
+  &__minibio {
+    margin-top: 1rem;
+    font-size:map-get(variables.$font-sizes, 'sm');
+  }
 }
 
 .list-speaker--with-info {

--- a/frontend/stylesheets/components/_list-speaker.scss
+++ b/frontend/stylesheets/components/_list-speaker.scss
@@ -48,7 +48,7 @@
 
     &-link:not(:hover) {
       color: variables.$base-font-color;
-    } 
+    }
   }
 
   &__bio {
@@ -57,10 +57,6 @@
     &--mini {
       margin-top: 0.6rem;
     }
-  }
-  &__minibio {
-    margin-top: 0.6rem;
-    font-size:map-get(variables.$font-sizes, 'sm');
   }
 }
 

--- a/src/_components/list_speaker.liquid
+++ b/src/_components/list_speaker.liquid
@@ -20,11 +20,11 @@
       <p class="list-speaker__bio">{{ speaker.bio }}</p>
     </div>
     {% else %}
-    {% if speaker.mini_bio %}
-    <div class="list-speaker__minibio">
-      {{ speaker.mini_bio }}
-    </div>
-    {% endif %}
+      {% if speaker.mini_bio %}
+      <small class="list-speaker__bio list-speaker__bio--mini">
+        {{ speaker.mini_bio }}
+      </small>
+      {% endif %}
     {% endif %}
   </li>
   {% endfor %}


### PR DESCRIPTION
## What happened

Fix markup from #302 
 
## Insight

`N/A`
 
## Proof Of Work

The list of keynote speakers looks great:

![image](https://github.com/bangkokrb/rubyconfth/assets/696529/d60158d2-1467-4b8c-8c80-b73ece00451d)
