### PR TITLE
Change domain for analytics

### DIFF
--- a/src/_components/analytics.liquid
+++ b/src/_components/analytics.liquid
@@ -1,1 +1,1 @@
-<script src="https://fs.rubyconfth.com/script.js" data-site="FOCVQRVQ" defer></script>
+<script src="https://cdn.usefathom.com/script.js" data-site="FOCVQRVQ" defer></script>


### PR DESCRIPTION
## What happened

Update URL for fathom analytics
 
## Insight

<details>
<summary>Email received:
</summary>

Hi Matt,

You’re getting this email because you created a custom domain at some point using Fathom Analytics.

We've had a few reports of custom domains not collecting data due to expired SSL certificates that our vendor isn’t renewing 
automatically, which is unacceptable to us, and we take full responsibility for this.

We’ve tried to fix this issue with our vendor but aren’t getting anywhere, so you need to stop using your Fathom custom domains right now.

Please switch the script domain you use on your website to “cdn.usefathom.com/script.js” as soon as possible. This endpoint includes EU 
Isolation out of the box.

Alternatively, if you need to use Extreme EU Isolation, where ALL global traffic is routed through the EU, please use 
“cdn-eu.usefathom.com/script.js“ instead.

Despite our best efforts, some ad-blockers now block custom domains, so they offer no benefit over using our standard embed code. We are 
working on a reverse-proxy solution, which we’ll launch soon.

Again, apologies here. Not collecting data for you is a worst-case scenario for our business, and we are taking steps to avoid this in the 
future. But you have our word that we’ll do better.

Questions? Hit reply.

Yours,

Paul & Jack
Cofounders, Fathom Analytics

</details>

## Proof Of Work

`N/A`