### PR TITLE
Add schedule

### DIFF
--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -1,28 +1,78 @@
-# - start_at: "8:00"
-#   end_at: "9:00"
-#   title: "Registration & Conference Door Opens"
-# - start_at: "9:00"
-#   end_at: "9:10"
-#   title: "Welcome Address"
-# - start_at:
-#   end_at: 
-#   title: 
-#   speaker_id: 
-#   slides_url: 
-#   youtube_id: 
-# - start_at: "10:30"
-#   end_at: "10:50"
-#   title: "Coffee Break"
-# - start_at: "12:30"
-#   end_at: "13:50"
-#   title: "Buffet Lunch"
-# - start_at: "15:05"
-#   end_at: "15:35"
-#   title: "Coffee Break"
-# - start_at: "17:00"
-#   end_at: "17:10"
-#   title: "Closing remarks & announcements"
-# - start_at: "18:00"
-#   end_at: "22:00"
-#   title: "Official Party 🥳"
-#   subtitle: "at TBD"
+- start_at: "8:00"
+  end_at: "9:00"
+  title: "Registration & Conference Door Opens"
+- start_at: "9:00"
+  end_at: "9:10"
+  title: "Welcome Address"
+- start_at: "9:10"
+  end_at: "9:55"
+  title: "Keynote"
+  speaker_id: matz
+#   slides_url:
+#   youtube_id:
+- start_at: "10:00"
+  end_at: "10:30"
+  title: "Component Driven UI with ViewComponent gem"
+  speaker_id: radoslav-stankov
+#   slides_url:
+#   youtube_id:
+- start_at: "10:30"
+  end_at: "10:50"
+  title: "Coffee Break"
+- start_at: "10:50"
+  end_at: "11:20"
+  title: "Learn to delegate; like a boss"
+  speaker_id:
+    - elle-meredith
+    - lachlan-hardy
+#   slides_url:
+#   youtube_id:
+- start_at: "11:25"
+  end_at: "11:55"
+  title: "Error 418 - I'm a teapot"
+  speaker_id: matthew-lindfield-seager
+#   slides_url:
+#   youtube_id:
+- start_at: "12:00"
+  end_at: "12:30"
+  title: "Big Corps, Big Worries. Some points on selling Ruby to Big Corps."
+  speaker_id: chakrit-wichian
+#   slides_url:
+#   youtube_id:
+- start_at: "12:30"
+  end_at: "13:50"
+  title: "Buffet Lunch"
+- start_at: "14:00"
+  end_at: "14:30"
+  title: "BYOJ: Build your own JIT with Ruby"
+  speaker_id: faraaz-ahmad
+#   slides_url:
+#   youtube_id:
+- start_at: "14:35"
+  end_at: "15:05"
+  title: "Introducing Living Documentation"
+  speaker_id: steven-r-baker
+#   slides_url:
+#   youtube_id:
+- start_at: "15:05"
+  end_at: "15:35"
+  title: "Coffee Break"
+- start_at: "15:35"
+  end_at: "16:05"
+  title: "Data indexing with RGB (Ruby, Graphs and Bitmaps)"
+  speaker_id: benji-lewis
+#   slides_url:
+#   youtube_id:
+- start_at: "16:10"
+  end_at: "16:55"
+  title: "Keynote: Breaking Barriers — Empowering the Unbanked with Innovative Tech"
+  speaker_id: bernard-banta
+#   slides_url:
+#   youtube_id:
+- start_at: "17:00"
+  end_at: "17:10"
+  title: "Closing remarks & announcements"
+- start_at: "18:00"
+  end_at: "22:00"
+  title: "Official Party 🥳"
+  subtitle: "at TBD"

--- a/src/_data/schedule/day_two.yml
+++ b/src/_data/schedule/day_two.yml
@@ -1,23 +1,72 @@
-# - start_at: "8:00"
-#   end_at: "9:00"
-#   title: "Conference Door Opens"
-# - start_at: "9:00"
-#   end_at: "9:10"
-#   title: "Welcome Address"
-# - start_at: 
-#   end_at: 
-#   title: 
-#   speaker_id: 
-#   youtube_id: 
-# - start_at: "10:30"
-#   end_at: "10:50"
-#   title: "Coffee Break"
-# - start_at: "12:30"
-#   end_at: "13:50"
-#   title: "Buffet Lunch"
-# - start_at: "15:05"
-#   end_at: "15:35"
-#   title: "Coffee Break"
-# - start_at: "17:00"
-#   end_at: "17:10"
-#   title: "Closing remarks & announcements"
+- start_at: "8:00"
+  end_at: "9:00"
+  title: "Conference Door Opens"
+- start_at: "9:00"
+  end_at: "9:10"
+  title: "Welcome Address"
+- start_at: "9:10"
+  end_at: "9:55"
+  title: "Keynote"
+  speaker_id: jemma-issroff
+#   slides_url:
+#   youtube_id:
+- start_at: "10:00"
+  end_at: "10:30"
+  title: "A Beginner's Complete Guide to Microcontroller Programming with Ruby"
+  speaker_id: hitoshi-hasumi
+#   slides_url:
+#   youtube_id:
+- start_at: "10:30"
+  end_at: "10:50"
+  title: "Coffee Break"
+- start_at: "10:50"
+  end_at: "11:20"
+  title: "Avoiding Disaster: Practical Strategies for Incident Prevention"
+  speaker_id: huy-du
+#   slides_url:
+#   youtube_id:
+- start_at: "11:25"
+  end_at: "11:55"
+  title: "Event Streaming Patterns for Ruby Services"
+  speaker_id: brad-urani
+#   slides_url:
+#   youtube_id:
+- start_at: "12:00"
+  end_at: "12:30"
+  title: "The Art of Abstracting: Key Factors for Success in a Core/Platform/BuildingBlocks team"
+  speaker_id: omar-sotillo-franco
+#   slides_url:
+#   youtube_id:
+- start_at: "12:30"
+  end_at: "13:50"
+  title: "Buffet Lunch"
+- start_at: "14:00"
+  end_at: "14:30"
+  title: "Kickboxer vs Ruby - the state of MRuby, JRuby and CRuby"
+  speaker_id:
+    - michael-milewski
+    - selena-small
+#   slides_url:
+#   youtube_id:
+- start_at: "14:35"
+  end_at: "15:05"
+  title: "The world of Passkeys 🤝🏽 Ruby"
+  speaker_id: helio-cola
+#   slides_url:
+#   youtube_id:
+- start_at: "15:05"
+  end_at: "15:35"
+  title: "Coffee Break"
+- start_at: "15:35"
+  end_at: "16:05"
+  title: "Rails Performance Monitoring 101: A Primer for Developers"
+  speaker_id: rishi-jain
+#   slides_url:
+#   youtube_id:
+- start_at: "16:10"
+  end_at: "16:55"
+  title: "Keynote"
+  speaker_id: ben-halpern
+- start_at: "17:00"
+  end_at: "17:10"
+  title: "Closing remarks & announcements"

--- a/src/_data/speakers.yml
+++ b/src/_data/speakers.yml
@@ -32,7 +32,7 @@
   photo_url: /images/speakers/jemma2.jpg
   type: keynote
   mini_bio: Founder of wnb.rb, GC expert
-  bio: Jemma Issroff is a Ruby Core committer who works on Shopify's Ruby Infrastructure team. She is also a co-founder of WNB.rb, a women / non-binary Ruby community, and a co-host on The Ruby on Rails Podcast. 
+  bio: Jemma Issroff is a Ruby Core committer who works on Shopify's Ruby Infrastructure team. She is also a co-founder of WNB.rb, a women / non-binary Ruby community, and a co-host on The Ruby on Rails Podcast.
   website: https://jemma.dev/
 - id: ben-halpern
   first_name: Ben
@@ -62,7 +62,7 @@
   bio: |
     He(lio) has created things primarily in C/C++ & Ruby, over the past 20+ years.
     He first met Ruby at v1.8.7 and Rails 2.x in 2010 and he is a Happy Developer since then.
-    He is currently a part-time Rails consultant, while building a new product and doing some OSS!"
+    He is currently a part-time Rails consultant, while building a new product and doing some OSS!
 - id: brad-urani
   first_name: Brad
   last_name: Urani

--- a/src/schedule.md
+++ b/src/schedule.md
@@ -2,7 +2,7 @@
 layout: default
 page_class: schedule
 title: "Schedule"
-published: false
+published: true
 ---
 
 <div class="schedule-browser" data-controller="schedule">
@@ -22,7 +22,7 @@ published: false
       {% render "table_schedule", events: site.data.schedule.day_one, speakers: site.data.speakers %}
     </div>
 
-    <div class="schedule-browser__tabpane" data-day="day-2" role="tabpanel">  
+    <div class="schedule-browser__tabpane" data-day="day-2" role="tabpanel">
       {% render "table_schedule", events: site.data.schedule.day_two, speakers: site.data.speakers %}
     </div>
   </div>


### PR DESCRIPTION
## What happened

Added the schedule for both days

## Insight

Schedule pages are now done but still miss the titles for most of the keynotes :-/

## Proof Of Work

<img width="979" alt="Screenshot 2023-07-30 at 14 16 01" src="https://github.com/bangkokrb/rubyconfth/assets/47985/3a4f115d-ed51-4d1c-ab0b-b1ea388ef959">

<img width="927" alt="Screenshot 2023-07-30 at 14 16 12" src="https://github.com/bangkokrb/rubyconfth/assets/47985/6e30a973-4269-44a6-9175-76802cda1b5c">
