### PR TITLE
Add a redirect /notgoing

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,3 +17,7 @@
 [[redirects]]
   from = "/tickets"
   to = "https://www.eventpop.me/e/15095/rubyconfth-2023"
+
+[[redirects]]
+  from = "/notgoing"
+  to = "https://www.eventpop.me/e/15095/rubyconfth-2023#ticket_types_41411"


### PR DESCRIPTION
## What happened

Adds a redirect to rubyconfth.com/notgoing that redirects to eventpop with the correct ticket type
 
## Insight

To be referenced in upcoming social media post/email
 
## Proof Of Work

https://deploy-preview-325--bangkokrb-rubyconfth.netlify.app/notgoing

	
