### PR TITLE
Add a redirect for student registration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,3 +25,7 @@
 [[redirects]]
   from = "/spin"
   to = "https://rubyconfth-luckydraw.netlify.app/"
+
+[[redirects]]
+  from = "/students"
+  to = "https://forms.gle/HHCqvi6UGHgFyqyH7"


### PR DESCRIPTION
## What happened

Add a redirect to the Google form for students to register for a free ticket.

## Insight

The form will be used at Ruby Tuesday #48

The form is below:

<img width="754" alt="image" src="https://github.com/bangkokrb/rubyconfth/assets/696529/4e4539fd-88e8-4597-9b63-af74871221dd">

 
## Proof Of Work

Go to: https://deploy-preview-339--bangkokrb-rubyconfth.netlify.app/students