### PR TITLE
Add links to the speakers' slides

### DIFF
--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -25,13 +25,13 @@
   speaker_id:
     - elle-meredith
     - lachlan-hardy
-#   slides_url:
+  slides_url: "https://speakerdeck.com/blackmill/learn-to-delegate-like-a-boss"
 #   youtube_id:
 - start_at: "11:25"
   end_at: "11:55"
   title: "Error 418 - I'm a teapot"
   speaker_id: matthew-lindfield-seager
-#   slides_url:
+  slides_url: "https://www.matt17r.com/rubyconfth-slides/"
 #   youtube_id:
 - start_at: "12:00"
   end_at: "12:30"
@@ -46,7 +46,7 @@
   end_at: "14:30"
   title: "BYOJ: Build your own JIT with Ruby"
   speaker_id: faraaz-ahmad
-#   slides_url:
+  slides_url: "https://speakerdeck.com/faraazahmad/byoj-build-your-own-jit-rubyconfth-2023"
 #   youtube_id:
 - start_at: "14:35"
   end_at: "15:05"

--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -52,7 +52,7 @@
   end_at: "15:05"
   title: "Cultivating Instinct"
   speaker_id: katrina-owen
-#   slides_url:
+  slides_url: "https://speakerdeck.com/kytrinyx/cultivating-instinct"
 #   youtube_id:
 - start_at: "15:05"
   end_at: "15:35"
@@ -61,7 +61,7 @@
   end_at: "16:05"
   title: "Data indexing with RGB (Ruby, Graphs and Bitmaps)"
   speaker_id: benji-lewis
-#   slides_url:
+  slides_url: "https://docs.google.com/presentation/d/1hDWt4JQXVrPcrdmFWSSCVI9LYn-ZdPaS5ZhTVMBFoZI/edit?usp=sharing"
 #   youtube_id:
 - start_at: "16:10"
   end_at: "16:55"

--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -37,7 +37,7 @@
   end_at: "12:30"
   title: "Big Corps, Big Worries. Some points on selling Ruby to Big Corps."
   speaker_id: chakrit-wichian
-#   slides_url:
+  slides_url: "https://drive.google.com/file/d/1c7MrY73gQR--LnM4VfIvjICjTsjr-PQ5/view"
 #   youtube_id:
 - start_at: "12:30"
   end_at: "13:50"

--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -14,7 +14,7 @@
   end_at: "10:30"
   title: "Component Driven UI with ViewComponent gem"
   speaker_id: radoslav-stankov
-#   slides_url:
+  slides_url: "https://speakerdeck.com/rstankov/component-driven-ui-with-viewcomponent-gem"
 #   youtube_id:
 - start_at: "10:30"
   end_at: "10:50"

--- a/src/_data/schedule/day_two.yml
+++ b/src/_data/schedule/day_two.yml
@@ -23,7 +23,7 @@
   end_at: "11:20"
   title: "Avoiding Disaster: Practical Strategies for Error Handling"
   speaker_id: huy-du
-#   slides_url:
+  slides_url: "https://speakerdeck.com/dugiahuy/avoiding-disaster-practical-strategies-for-error-handling"
 #   youtube_id:
 - start_at: "11:25"
   end_at: "11:55"
@@ -52,7 +52,7 @@
   end_at: "15:05"
   title: "The world of Passkeys 🤝🏽 Ruby"
   speaker_id: helio-cola
-#   slides_url:
+  slides_url: "https://speakerdeck.com/heliocola/the-world-of-passkeys-ruby"
 #   youtube_id:
 - start_at: "15:05"
   end_at: "15:35"


### PR DESCRIPTION
## What happened

Update the `yml` config file with the URLs to the speakers' slides.
 
## Insight

The links were shared on Slack.
 
## Proof Of Work

<img width="894" alt="image" src="https://github.com/bangkokrb/rubyconfth/assets/696529/a163708b-1807-4c3c-99f5-3a6d4b377cc2">