### PR TITLE
Add links to video recordings

### DIFF
--- a/frontend/stylesheets/components/_card-talk.scss
+++ b/frontend/stylesheets/components/_card-talk.scss
@@ -9,7 +9,7 @@
       font-size: map-get(variables.$font-sizes, 'xl');
     }
 
-    > a:not(:hover) {
+    >a:not(:hover) {
       color: variables.$base-font-color;
       text-decoration: none;
     }
@@ -35,8 +35,13 @@
     border-radius: 50%;
   }
 
-  &__profile + &__info {
+  &__profile+&__info {
     padding-left: 0.5rem;
+  }
+
+  &__cancellation {
+    margin-top: 1rem;
+    font-size: smaller;
   }
 
   &__social {
@@ -54,7 +59,7 @@
   }
 
   // For dual speaker talks
-  & + & {
+  &+& {
     margin-top: 0.5rem;
- }
+  }
 }

--- a/frontend/stylesheets/components/_card-talk.scss
+++ b/frontend/stylesheets/components/_card-talk.scss
@@ -9,7 +9,7 @@
       font-size: map-get(variables.$font-sizes, 'xl');
     }
 
-    >a:not(:hover) {
+    > a:not(:hover) {
       color: variables.$base-font-color;
       text-decoration: none;
     }
@@ -35,7 +35,7 @@
     border-radius: 50%;
   }
 
-  &__profile+&__info {
+  &__profile + &__info {
     padding-left: 0.5rem;
   }
 
@@ -59,7 +59,7 @@
   }
 
   // For dual speaker talks
-  &+& {
+  & + & {
     margin-top: 0.5rem;
   }
 }

--- a/src/_components/card_talk.liquid
+++ b/src/_components/card_talk.liquid
@@ -36,6 +36,11 @@
         </a>
       </div>
       {% endif %}
+      {% if event.cancellation_note %}
+      <div class="card-talk__cancellation">
+        <small>{{ event.cancellation_note }}</small>
+      </div>
+    {% endif %}
     </div>
   </div>
 </div>

--- a/src/_components/card_talk.liquid
+++ b/src/_components/card_talk.liquid
@@ -36,11 +36,11 @@
         </a>
       </div>
       {% endif %}
-      {% if event.cancellation_note %}
-      <div class="card-talk__cancellation">
-        <small>{{ event.cancellation_note }}</small>
-      </div>
-    {% endif %}
     </div>
   </div>
+  {% if event.cancellation_note %}
+    <div class="card-talk__cancellation">
+      {{ event.cancellation_note }}
+    </div>
+  {% endif %}
 </div>

--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -9,13 +9,13 @@
   title: "Keynote: 30 Years of Ruby"
   speaker_id: matz
 #   slides_url:
-#   youtube_id:
+  youtube_id: v9htIvpqaug
 - start_at: "10:00"
   end_at: "10:30"
   title: "Component Driven UI with ViewComponent gem"
   speaker_id: radoslav-stankov
   slides_url: "https://speakerdeck.com/rstankov/component-driven-ui-with-viewcomponent-gem"
-#   youtube_id:
+  youtube_id: f02fB2gEg6k
 - start_at: "10:30"
   end_at: "10:50"
   title: "Coffee Break"
@@ -26,19 +26,19 @@
     - elle-meredith
     - lachlan-hardy
   slides_url: "https://speakerdeck.com/blackmill/learn-to-delegate-like-a-boss"
-#   youtube_id:
+  youtube_id: RWVe2EXCE9M
 - start_at: "11:25"
   end_at: "11:55"
   title: "Error 418 - I'm a teapot"
   speaker_id: matthew-lindfield-seager
   slides_url: "https://www.matt17r.com/rubyconfth-slides/"
-#   youtube_id:
+  youtube_id: gzww742hcuE
 - start_at: "12:00"
   end_at: "12:30"
   title: "Big Corps, Big Worries. Some points on selling Ruby to Big Corps."
   speaker_id: chakrit-wichian
   slides_url: "https://drive.google.com/file/d/1c7MrY73gQR--LnM4VfIvjICjTsjr-PQ5/view"
-#   youtube_id:
+  youtube_id: nynzHHNQbDA
 - start_at: "12:30"
   end_at: "13:50"
   title: "Buffet Lunch"
@@ -47,13 +47,13 @@
   title: "BYOJ: Build your own JIT with Ruby"
   speaker_id: faraaz-ahmad
   slides_url: "https://speakerdeck.com/faraazahmad/byoj-build-your-own-jit-rubyconfth-2023"
-#   youtube_id:
+  youtube_id: PGElh63JnUA
 - start_at: "14:35"
   end_at: "15:05"
   title: "Cultivating Instinct"
   speaker_id: katrina-owen
   slides_url: "https://speakerdeck.com/kytrinyx/cultivating-instinct"
-#   youtube_id:
+  youtube_id: htGjAZROOUo
 - start_at: "15:05"
   end_at: "15:35"
   title: "Coffee Break"
@@ -62,13 +62,13 @@
   title: "Data indexing with RGB (Ruby, Graphs and Bitmaps)"
   speaker_id: benji-lewis
   slides_url: "https://docs.google.com/presentation/d/1hDWt4JQXVrPcrdmFWSSCVI9LYn-ZdPaS5ZhTVMBFoZI/edit?usp=sharing"
-#   youtube_id:
+  youtube_id: xz9FMFGV2Eo
 - start_at: "16:10"
   end_at: "16:55"
   title: "Keynote: Breaking Barriers — Empowering the Unbanked with Innovative Tech"
   speaker_id: bernard-banta
 #   slides_url:
-#   youtube_id:
+  youtube_id: oRtgSlJeiuw
 - start_at: "17:00"
   end_at: "17:10"
   title: "Closing remarks & announcements"

--- a/src/_data/schedule/day_one.yml
+++ b/src/_data/schedule/day_one.yml
@@ -15,7 +15,7 @@
   title: "Component Driven UI with ViewComponent gem"
   speaker_id: radoslav-stankov
   slides_url: "https://speakerdeck.com/rstankov/component-driven-ui-with-viewcomponent-gem"
-  youtube_id: f02fB2gEg6k
+  youtube_id: ar8RMbDPoSY
 - start_at: "10:30"
   end_at: "10:50"
   title: "Coffee Break"

--- a/src/_data/schedule/day_two.yml
+++ b/src/_data/schedule/day_two.yml
@@ -35,8 +35,16 @@
   end_at: "12:30"
   title: "The Art of Abstracting: Key Factors for Success in a Core/Platform/BuildingBlocks team"
   speaker_id: omar-sotillo-franco
-#   slides_url:
-#   youtube_id:
+  cancellation_note: "Unfortunately, Omar was unable to present this talk due to ill-health, we look forward to welcoming him to a future RubyConfTH! This session was replaced by a panel discussion, below."
+- start_at: "12:00"
+  end_at: "12:30"
+  title: "Panel Discussion"
+  speaker_id:
+    - jemma-issroff
+    - selena-small
+    - brad-urani
+    - elle-meredith
+  youtube_id: lYO7w-sSLgs
 - start_at: "12:30"
   end_at: "13:50"
   title: "Buffet Lunch"

--- a/src/_data/schedule/day_two.yml
+++ b/src/_data/schedule/day_two.yml
@@ -9,13 +9,13 @@
   title: "Keynote: Popping into Ruby"
   speaker_id: jemma-issroff
 #   slides_url:
-#   youtube_id:
+  youtube_id: vsiFjuBt-v8
 - start_at: "10:00"
   end_at: "10:30"
   title: "A Beginner's Complete Guide to Microcontroller Programming with Ruby"
   speaker_id: hitoshi-hasumi
 #   slides_url:
-#   youtube_id:
+  youtube_id: GkIRr1Xm8GU
 - start_at: "10:30"
   end_at: "10:50"
   title: "Coffee Break"
@@ -24,13 +24,13 @@
   title: "Avoiding Disaster: Practical Strategies for Error Handling"
   speaker_id: huy-du
   slides_url: "https://speakerdeck.com/dugiahuy/avoiding-disaster-practical-strategies-for-error-handling"
-#   youtube_id:
+  youtube_id: Ci1f9NKuOyY
 - start_at: "11:25"
   end_at: "11:55"
   title: "Event Streaming Patterns for Ruby Services"
   speaker_id: brad-urani
 #   slides_url:
-#   youtube_id:
+  youtube_id: RBj4S9S-fJI
 - start_at: "12:00"
   end_at: "12:30"
   title: "The Art of Abstracting: Key Factors for Success in a Core/Platform/BuildingBlocks team"
@@ -47,13 +47,13 @@
     - michael-milewski
     - selena-small
 #   slides_url:
-#   youtube_id:
+  youtube_id: JQRT6-Yjumo
 - start_at: "14:35"
   end_at: "15:05"
   title: "The world of Passkeys 🤝🏽 Ruby"
   speaker_id: helio-cola
   slides_url: "https://speakerdeck.com/heliocola/the-world-of-passkeys-ruby"
-#   youtube_id:
+  youtube_id: 3UiVL6TnDr8
 - start_at: "15:05"
   end_at: "15:35"
   title: "Coffee Break"
@@ -62,11 +62,12 @@
   title: "Rails Performance Monitoring 101: A Primer for Developers"
   speaker_id: rishi-jain
 #   slides_url:
-#   youtube_id:
+  youtube_id: 41HtDXJj-fw
 - start_at: "16:10"
   end_at: "16:55"
   title: "Keynote: Thriving in Uncertainty"
   speaker_id: ben-halpern
+  youtube_id: L01VKh78cnQ
 - start_at: "17:00"
   end_at: "17:10"
   title: "Closing remarks & announcements"


### PR DESCRIPTION
## What happened

Update the  schedule `yml` files with YouTube IDs

## Insight

Since Omar could not give his talk, a note was added in the schedule and a link to the panel discussion was added in replacement.
 
## Proof Of Work

<img width="1125" alt="image" src="https://github.com/bangkokrb/rubyconfth/assets/696529/85765839-a383-4f02-b175-e86e08f069fe">